### PR TITLE
Fix python3 DeprecationWarning for inspect.getargspec()

### DIFF
--- a/accepts/__init__.py
+++ b/accepts/__init__.py
@@ -18,7 +18,12 @@ def _err_msg(func, args, pos, required_types):
 
 
 def _func_args(f):
-    return len(inspect.getargspec(f).args)
+    try:
+        # getargspec() is deprecated in python3, so use drop-in-replacement getfullargspec() whenever available
+        return len(inspect.getfullargspec(f).args)
+    except AttributeError:
+        # fall back to getargspec() if getfullargspec() is not available (python2)
+        return len(inspect.getargspec(f).args)
 
 
 def _validate_args(f, args, types):


### PR DESCRIPTION
Since python3.0, inspect.getargspec() is marked as deprecated.
inspect.getfullargspec() provides a compatible replacement, but with support for python3-features.
Therefore, whenever available inspect.getfullargspec() is used now. If it is not available, which is the case in python 2, the old inspect.getargspec() is used.